### PR TITLE
Allow approx to be used without the standard library.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ keywords = ["math", "floating-point", "equality", "test", "assert"]
 
 [lib]
 name = "approx"
+
+[features]
+  no_std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,15 @@
 //! - [What Every Computer Scientist Should Know About Floating-Point Arithmetic]
 //!   (https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html)
 
+#![cfg_attr(feature="no_std", no_std)]
+#![cfg_attr(feature="no_std", feature(core_float))]
+#[cfg(feature="no_std")]
+use core as std;
+
+#[cfg(feature="no_std")]
+#[allow(unused_imports)] // Get a warning otherwise. This seems like a bug.
+use core::num::Float;
+
 mod macros;
 
 /// Equality comparisons based on floating point tolerances.


### PR DESCRIPTION
This adds the option to pass the feature flad `no_std` which removes all dependence on `std`.

Unfortunately, due to [Rust issue #32110](https://github.com/rust-lang/rust/issues/32110), using this feature requires a nightly compiler.

Once the `core::num::Float` stuff is stabilized, the `no_std` flag that I have just added will no longer be necessary, so I understand if you would prefer not to merge this PR until then.