### PR TITLE
Fix opposite infinities

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,10 +153,18 @@ pub trait ApproxEq: Sized {
     fn default_max_ulps() -> u32;
 
     /// A test for equality that uses a relative comparison if the values are far apart.
-    fn relative_eq(&self, other: &Self, epsilon: Self::Epsilon, max_relative: Self::Epsilon) -> bool;
+    fn relative_eq(&self,
+                   other: &Self,
+                   epsilon: Self::Epsilon,
+                   max_relative: Self::Epsilon)
+                   -> bool;
 
     /// The inverse of `ApproxEq::relative_eq`.
-    fn relative_ne(&self, other: &Self, epsilon: Self::Epsilon, max_relative: Self::Epsilon) -> bool {
+    fn relative_ne(&self,
+                   other: &Self,
+                   epsilon: Self::Epsilon,
+                   max_relative: Self::Epsilon)
+                   -> bool {
         !Self::relative_eq(self, other, epsilon, max_relative)
     }
 
@@ -280,7 +288,11 @@ impl<'a, T: ApproxEq> ApproxEq for &'a mut T {
     }
 
     #[inline]
-    fn relative_eq(&self, other: &&'a mut T, epsilon: T::Epsilon, max_relative: T::Epsilon) -> bool {
+    fn relative_eq(&self,
+                   other: &&'a mut T,
+                   epsilon: T::Epsilon,
+                   max_relative: T::Epsilon)
+                   -> bool {
         T::relative_eq(*self, *other, epsilon, max_relative)
     }
 
@@ -302,7 +314,9 @@ pub struct Relative<'a, T: 'a + ApproxEq> {
     pub max_relative: T::Epsilon,
 }
 
-impl<'a, T> Relative<'a, T> where T: ApproxEq {
+impl<'a, T> Relative<'a, T>
+    where T: ApproxEq
+{
     /// The beginning of a chained equality expression, using a relative based comparison.
     ///
     /// ```rust
@@ -328,27 +342,31 @@ impl<'a, T> Relative<'a, T> where T: ApproxEq {
     /// Replace the epsilon value with the one specified.
     #[inline]
     pub fn epsilon(self, epsilon: T::Epsilon) -> Relative<'a, T> {
-        Relative { epsilon: epsilon, ..self }
+        Relative {
+            epsilon: epsilon,
+            ..self
+        }
     }
 
     /// Replace the maximum relative value with the one specified.
     #[inline]
     pub fn max_relative(self, max_relative: T::Epsilon) -> Relative<'a, T> {
-        Relative { max_relative: max_relative, ..self }
+        Relative {
+            max_relative: max_relative,
+            ..self
+        }
     }
 
     /// Peform the equality comparison
     #[inline]
     pub fn eq(self) -> bool {
-        let Relative { lhs, rhs, epsilon, max_relative } = self;
-        T::relative_eq(lhs, rhs, epsilon, max_relative)
+        T::relative_eq(self.lhs, self.rhs, self.epsilon, self.max_relative)
     }
 
     /// Peform the inequality comparison
     #[inline]
     pub fn ne(self) -> bool {
-        let Relative { lhs, rhs, epsilon, max_relative } = self;
-        T::relative_ne(lhs, rhs, epsilon, max_relative)
+        T::relative_ne(self.lhs, self.rhs, self.epsilon, self.max_relative)
     }
 }
 
@@ -364,7 +382,9 @@ pub struct Ulps<'a, T: 'a + ApproxEq> {
     pub max_ulps: u32,
 }
 
-impl<'a, T> Ulps<'a, T> where T: ApproxEq {
+impl<'a, T> Ulps<'a, T>
+    where T: ApproxEq
+{
     /// The beginning of a chained equality expression, using an ULPs based comparison.
     ///
     /// ```rust
@@ -390,26 +410,30 @@ impl<'a, T> Ulps<'a, T> where T: ApproxEq {
     /// Replace the epsilon value with the one specified.
     #[inline]
     pub fn epsilon(self, epsilon: T::Epsilon) -> Ulps<'a, T> {
-        Ulps { epsilon: epsilon, ..self }
+        Ulps {
+            epsilon: epsilon,
+            ..self
+        }
     }
 
     /// Replace the max ulps value with the one specified.
     #[inline]
-    pub fn max_ulps(self, max_ulps:u32) -> Ulps<'a, T> {
-        Ulps { max_ulps: max_ulps, ..self }
+    pub fn max_ulps(self, max_ulps: u32) -> Ulps<'a, T> {
+        Ulps {
+            max_ulps: max_ulps,
+            ..self
+        }
     }
 
     /// Peform the equality comparison
     #[inline]
     pub fn eq(self) -> bool {
-        let Ulps { lhs, rhs, epsilon, max_ulps } = self;
-        T::ulps_eq(lhs, rhs, epsilon, max_ulps)
+        T::ulps_eq(self.lhs, self.rhs, self.epsilon, self.max_ulps)
     }
 
     /// Peform the inequality comparison
     #[inline]
     pub fn ne(self) -> bool {
-        let Ulps { lhs, rhs, epsilon, max_ulps } = self;
-        T::ulps_ne(lhs, rhs, epsilon, max_ulps)
+        T::ulps_ne(self.lhs, self.rhs, self.epsilon, self.max_ulps)
     }
 }

--- a/tests/relative_eq.rs
+++ b/tests/relative_eq.rs
@@ -107,7 +107,7 @@ mod test_f32 {
     fn test_infinity() {
         assert_relative_eq!(f32::INFINITY, f32::INFINITY);
         assert_relative_eq!(f32::NEG_INFINITY, f32::NEG_INFINITY);
-        assert_relative_eq!(f32::NEG_INFINITY, f32::INFINITY);
+        assert_relative_ne!(f32::NEG_INFINITY, f32::INFINITY);
         assert_relative_eq!(f32::INFINITY, f32::MAX);
         assert_relative_eq!(f32::NEG_INFINITY, -f32::MAX);
     }
@@ -257,7 +257,7 @@ mod test_f64 {
     fn test_infinity() {
         assert_relative_eq!(f64::INFINITY, f64::INFINITY);
         assert_relative_eq!(f64::NEG_INFINITY, f64::NEG_INFINITY);
-        assert_relative_eq!(f64::NEG_INFINITY, f64::INFINITY);
+        assert_relative_ne!(f64::NEG_INFINITY, f64::INFINITY);
         assert_relative_eq!(f64::INFINITY, f64::MAX);
         assert_relative_eq!(f64::NEG_INFINITY, -f64::MAX);
     }

--- a/tests/ulps_eq.rs
+++ b/tests/ulps_eq.rs
@@ -107,7 +107,7 @@ mod test_f32 {
     fn test_infinity() {
         assert_ulps_eq!(f32::INFINITY, f32::INFINITY);
         assert_ulps_eq!(f32::NEG_INFINITY, f32::NEG_INFINITY);
-        // assert_ulps_eq!(f32::NEG_INFINITY, f32::INFINITY);
+        assert_ulps_ne!(f32::NEG_INFINITY, f32::INFINITY);
         assert_ulps_eq!(f32::INFINITY, f32::MAX);
         assert_ulps_eq!(f32::NEG_INFINITY, -f32::MAX);
     }
@@ -256,7 +256,7 @@ mod test_f64 {
     fn test_infinity() {
         assert_ulps_eq!(f64::INFINITY, f64::INFINITY);
         assert_ulps_eq!(f64::NEG_INFINITY, f64::NEG_INFINITY);
-        // assert_ulps_eq!(f64::NEG_INFINITY, f64::INFINITY);
+        assert_ulps_ne!(f64::NEG_INFINITY, f64::INFINITY);
         assert_ulps_eq!(f64::INFINITY, f64::MAX);
         assert_ulps_eq!(f64::NEG_INFINITY, -f64::MAX);
     }


### PR DESCRIPTION
Negative infinity should not equal positive infinity for both equality comparison functions. This makes this behavior consistent.

See the following comment for the solution used: https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/#comment-13922