### PR TITLE
Add ApproxEq::abs_diff_{eq|ne} functions and macros

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -14,6 +14,111 @@
 
 /// Predicate for testing the approximate equality of two values.
 #[macro_export]
+macro_rules! abs_diff_eq {
+    ($lhs:expr, $rhs:expr, $($opt:ident = $opt_val:expr),+) => {{
+        $crate::AbsDiff::default()$(.$opt($opt_val))+.eq(&$lhs, &$rhs)
+    }};
+    ($lhs:expr, $rhs:expr) => {{
+        $crate::AbsDiff::default().eq(&$lhs, &$rhs)
+    }};
+}
+
+/// Predicate for testing the approximate inequality of two values.
+#[macro_export]
+macro_rules! abs_diff_ne {
+    ($lhs:expr, $rhs:expr, $($opt:ident = $opt_val:expr),+) => {{
+        $crate::AbsDiff::default()$(.$opt($opt_val))+.ne(&$lhs, &$rhs)
+    }};
+    ($lhs:expr, $rhs:expr) => {{
+        $crate::AbsDiff::default().ne(&$lhs, &$rhs)
+    }};
+}
+
+#[macro_export]
+macro_rules! assert_abs_diff_eq {
+    ($given:expr, $expected:expr) => {{
+        let (given, expected) = (&($given), &($expected));
+
+        if !abs_diff_eq!(given, expected) {
+            panic!(
+"assert_abs_diff_eq!({}, {})
+
+    left  = {:?}
+    right = {:?}
+
+",
+                stringify!($given), stringify!($expected),
+                given, expected,
+            );
+        }
+    }};
+    ($given:expr, $expected:expr, $($opt:ident = $opt_val:expr),+) => {{
+        let (given, expected) = (&($given), &($expected));
+
+        if !abs_diff_eq!(given, expected, $($opt = $opt_val),+) {
+            panic!(
+"assert_abs_diff_eq!({}, {}, {})
+
+    left  = {:?}
+    right = {:?}
+
+",
+                stringify!($given), stringify!($expected),
+                stringify!($($opt = $opt_val),+),
+                given, expected,
+            );
+        }
+    }};
+    ($given:expr, $expected:expr,) => {
+        assert_abs_diff_eq!($given, $expected)
+    };
+    ($given:expr, $expected:expr, $($opt:ident = $opt_val:expr,)+) => {
+        assert_abs_diff_eq!($given, $expected, $($opt = $opt_val),+)
+    };
+}
+
+#[macro_export]
+macro_rules! assert_abs_diff_ne {
+    ($given:expr, $expected:expr) => {{
+        let (given, expected) = (&($given), &($expected));
+
+        if !abs_diff_ne!(given, expected) {
+            panic!(
+"assert_abs_diff_ne!({}, {})
+
+    left  = {:?}
+    right = {:?}
+
+",
+                stringify!($given), stringify!($expected),
+                given, expected,
+            );
+        }
+    }};
+    ($given:expr, $expected:expr, $($opt:ident = $opt_val:expr),+) => {{
+        let (given, expected) = (&($given), &($expected));
+
+        if !abs_diff_ne!(given, expected, $($opt = $opt_val),+) {
+            panic!(
+"assert_abs_diff_ne!({}, {}, {})
+
+    left  = {:?}
+    right = {:?}
+
+",
+                stringify!($given), stringify!($expected),
+                stringify!($($opt = $opt_val),+),
+                given, expected,
+            );
+        }
+    }};
+    ($given:expr, $expected:expr,) => {
+        assert_abs_diff_ne!($given, $expected)
+    };
+}
+
+/// Predicate for testing the approximate equality of two values.
+#[macro_export]
 macro_rules! relative_eq {
     ($lhs:expr, $rhs:expr, $($opt:ident = $opt_val:expr),+) => {{
         $crate::Relative::default()$(.$opt($opt_val))+.eq(&$lhs, &$rhs)
@@ -224,3 +329,4 @@ macro_rules! assert_ulps_ne {
         assert_ulps_ne!($given, $expected)
     };
 }
+

--- a/tests/abs_diff_eq.rs
+++ b/tests/abs_diff_eq.rs
@@ -1,0 +1,320 @@
+// Copyright 2015 Brendan Zabarauskas
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test cases derived from https://github.com/Pybonacci/puntoflotante.org/blob/master/content/errors/NearlyEqualsTest.java
+
+#[macro_use]
+extern crate approx;
+
+mod test_f32 {
+    use std::f32;
+
+    #[test]
+    fn test_big() {
+        assert_abs_diff_eq!(100000000.0f32, 100000001.0f32);
+        assert_abs_diff_eq!(100000001.0f32, 100000000.0f32);
+        assert_abs_diff_ne!(10000.0f32, 10001.0f32);
+        assert_abs_diff_ne!(10001.0f32, 10000.0f32);
+    }
+
+    #[test]
+    fn test_big_neg() {
+        assert_abs_diff_eq!(-100000000.0f32, -100000001.0f32);
+        assert_abs_diff_eq!(-100000001.0f32, -100000000.0f32);
+        assert_abs_diff_ne!(-10000.0f32, -10001.0f32);
+        assert_abs_diff_ne!(-10001.0f32, -10000.0f32);
+    }
+
+    #[test]
+    fn test_mid() {
+        assert_abs_diff_eq!(1.0000001f32, 1.0000002f32);
+        assert_abs_diff_eq!(1.0000002f32, 1.0000001f32);
+        assert_abs_diff_ne!(1.000001f32, 1.000002f32);
+        assert_abs_diff_ne!(1.000002f32, 1.000001f32);
+    }
+
+    #[test]
+    fn test_mid_neg() {
+        assert_abs_diff_eq!(-1.0000001f32, -1.0000002f32);
+        assert_abs_diff_eq!(-1.0000002f32, -1.0000001f32);
+        assert_abs_diff_ne!(-1.000001f32, -1.000002f32);
+        assert_abs_diff_ne!(-1.000002f32, -1.000001f32);
+    }
+
+    #[test]
+    fn test_small() {
+        assert_abs_diff_eq!(0.000010001f32, 0.000010002f32);
+        assert_abs_diff_eq!(0.000010002f32, 0.000010001f32);
+        assert_abs_diff_ne!(0.000001002f32, 0.0000001001f32);
+        assert_abs_diff_ne!(0.000001001f32, 0.0000001002f32);
+    }
+
+    #[test]
+    fn test_small_neg() {
+        assert_abs_diff_eq!(-0.000010001f32, -0.000010002f32);
+        assert_abs_diff_eq!(-0.000010002f32, -0.000010001f32);
+        assert_abs_diff_ne!(-0.000001002f32, -0.0000001001f32);
+        assert_abs_diff_ne!(-0.000001001f32, -0.0000001002f32);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_abs_diff_eq!(0.0f32, 0.0f32);
+        assert_abs_diff_eq!(0.0f32, -0.0f32);
+        assert_abs_diff_eq!(-0.0f32, -0.0f32);
+
+        assert_abs_diff_ne!(0.000001f32, 0.0f32);
+        assert_abs_diff_ne!(0.0f32, 0.000001f32);
+        assert_abs_diff_ne!(-0.000001f32, 0.0f32);
+        assert_abs_diff_ne!(0.0f32, -0.000001f32);
+    }
+
+    #[test]
+    fn test_epsilon() {
+        assert_abs_diff_eq!(0.0f32, 1e-40f32, epsilon = 1e-40f32);
+        assert_abs_diff_eq!(1e-40f32, 0.0f32, epsilon = 1e-40f32);
+        assert_abs_diff_eq!(0.0f32, -1e-40f32, epsilon = 1e-40f32);
+        assert_abs_diff_eq!(-1e-40f32, 0.0f32, epsilon = 1e-40f32);
+
+        assert_abs_diff_ne!(1e-40f32, 0.0f32, epsilon = 1e-41f32);
+        assert_abs_diff_ne!(0.0f32, 1e-40f32, epsilon = 1e-41f32);
+        assert_abs_diff_ne!(-1e-40f32, 0.0f32, epsilon = 1e-41f32);
+        assert_abs_diff_ne!(0.0f32, -1e-40f32, epsilon = 1e-41f32);
+    }
+
+    #[test]
+    fn test_max() {
+        assert_abs_diff_eq!(f32::MAX, f32::MAX);
+        assert_abs_diff_ne!(f32::MAX, -f32::MAX);
+        assert_abs_diff_ne!(-f32::MAX, f32::MAX);
+        assert_abs_diff_ne!(f32::MAX, f32::MAX / 2.0);
+        assert_abs_diff_ne!(f32::MAX, -f32::MAX / 2.0);
+        assert_abs_diff_ne!(-f32::MAX, f32::MAX / 2.0);
+    }
+
+    // NOTE: abs_diff_eq fails as numbers begin to get very large
+
+    // #[test]
+    // fn test_infinity() {
+    //     assert_abs_diff_eq!(f32::INFINITY, f32::INFINITY);
+    //     assert_abs_diff_eq!(f32::NEG_INFINITY, f32::NEG_INFINITY);
+    //     assert_abs_diff_ne!(f32::NEG_INFINITY, f32::INFINITY);
+    //     assert_abs_diff_eq!(f32::INFINITY, f32::MAX);
+    //     assert_abs_diff_eq!(f32::NEG_INFINITY, -f32::MAX);
+    // }
+
+    #[test]
+    fn test_nan() {
+        assert_abs_diff_ne!(f32::NAN, f32::NAN);
+
+        assert_abs_diff_ne!(f32::NAN, 0.0);
+        assert_abs_diff_ne!(-0.0, f32::NAN);
+        assert_abs_diff_ne!(f32::NAN, -0.0);
+        assert_abs_diff_ne!(0.0, f32::NAN);
+
+        assert_abs_diff_ne!(f32::NAN, f32::INFINITY);
+        assert_abs_diff_ne!(f32::INFINITY, f32::NAN);
+        assert_abs_diff_ne!(f32::NAN, f32::NEG_INFINITY);
+        assert_abs_diff_ne!(f32::NEG_INFINITY, f32::NAN);
+
+        assert_abs_diff_ne!(f32::NAN, f32::MAX);
+        assert_abs_diff_ne!(f32::MAX, f32::NAN);
+        assert_abs_diff_ne!(f32::NAN, -f32::MAX);
+        assert_abs_diff_ne!(-f32::MAX, f32::NAN);
+
+        assert_abs_diff_ne!(f32::NAN, f32::MIN_POSITIVE);
+        assert_abs_diff_ne!(f32::MIN_POSITIVE, f32::NAN);
+        assert_abs_diff_ne!(f32::NAN, -f32::MIN_POSITIVE);
+        assert_abs_diff_ne!(-f32::MIN_POSITIVE, f32::NAN);
+    }
+
+    #[test]
+    fn test_opposite_signs() {
+        assert_abs_diff_ne!(1.000000001f32, -1.0f32);
+        assert_abs_diff_ne!(-1.0f32, 1.000000001f32);
+        assert_abs_diff_ne!(-1.000000001f32, 1.0f32);
+        assert_abs_diff_ne!(1.0f32, -1.000000001f32);
+
+        assert_abs_diff_eq!(10.0 * f32::MIN_POSITIVE, 10.0 * -f32::MIN_POSITIVE);
+    }
+
+    #[test]
+    fn test_close_to_zero() {
+        assert_abs_diff_eq!(f32::MIN_POSITIVE, f32::MIN_POSITIVE);
+        assert_abs_diff_eq!(f32::MIN_POSITIVE, -f32::MIN_POSITIVE);
+        assert_abs_diff_eq!(-f32::MIN_POSITIVE, f32::MIN_POSITIVE);
+
+        assert_abs_diff_eq!(f32::MIN_POSITIVE, 0.0f32);
+        assert_abs_diff_eq!(0.0f32, f32::MIN_POSITIVE);
+        assert_abs_diff_eq!(-f32::MIN_POSITIVE, 0.0f32);
+        assert_abs_diff_eq!(0.0f32, -f32::MIN_POSITIVE);
+
+        assert_abs_diff_ne!(0.000001f32, -f32::MIN_POSITIVE);
+        assert_abs_diff_ne!(0.000001f32, f32::MIN_POSITIVE);
+        assert_abs_diff_ne!(f32::MIN_POSITIVE, 0.000001f32);
+        assert_abs_diff_ne!(-f32::MIN_POSITIVE, 0.000001f32);
+    }
+}
+
+#[cfg(test)]
+mod test_f64 {
+    use std::f64;
+
+    #[test]
+    fn test_big() {
+        assert_abs_diff_eq!(10000000000000000.0f64, 10000000000000001.0f64);
+        assert_abs_diff_eq!(10000000000000001.0f64, 10000000000000000.0f64);
+        assert_abs_diff_ne!(1000000000000000.0f64, 1000000000000001.0f64);
+        assert_abs_diff_ne!(1000000000000001.0f64, 1000000000000000.0f64);
+    }
+
+    #[test]
+    fn test_big_neg() {
+        assert_abs_diff_eq!(-10000000000000000.0f64, -10000000000000001.0f64);
+        assert_abs_diff_eq!(-10000000000000001.0f64, -10000000000000000.0f64);
+        assert_abs_diff_ne!(-1000000000000000.0f64, -1000000000000001.0f64);
+        assert_abs_diff_ne!(-1000000000000001.0f64, -1000000000000000.0f64);
+    }
+
+    #[test]
+    fn test_mid() {
+        assert_abs_diff_eq!(1.0000000000000001f64, 1.0000000000000002f64);
+        assert_abs_diff_eq!(1.0000000000000002f64, 1.0000000000000001f64);
+        assert_abs_diff_ne!(1.000000000000001f64, 1.000000000000002f64);
+        assert_abs_diff_ne!(1.000000000000002f64, 1.000000000000001f64);
+    }
+
+    #[test]
+    fn test_mid_neg() {
+        assert_abs_diff_eq!(-1.0000000000000001f64, -1.0000000000000002f64);
+        assert_abs_diff_eq!(-1.0000000000000002f64, -1.0000000000000001f64);
+        assert_abs_diff_ne!(-1.000000000000001f64, -1.000000000000002f64);
+        assert_abs_diff_ne!(-1.000000000000002f64, -1.000000000000001f64);
+    }
+
+    #[test]
+    fn test_small() {
+        assert_abs_diff_eq!(0.0000000100000001f64, 0.0000000100000002f64);
+        assert_abs_diff_eq!(0.0000000100000002f64, 0.0000000100000001f64);
+        assert_abs_diff_ne!(0.0000000100000001f64, 0.0000000010000002f64);
+        assert_abs_diff_ne!(0.0000000100000002f64, 0.0000000010000001f64);
+    }
+
+    #[test]
+    fn test_small_neg() {
+        assert_abs_diff_eq!(-0.0000000100000001f64, -0.0000000100000002f64);
+        assert_abs_diff_eq!(-0.0000000100000002f64, -0.0000000100000001f64);
+        assert_abs_diff_ne!(-0.0000000100000001f64, -0.0000000010000002f64);
+        assert_abs_diff_ne!(-0.0000000100000002f64, -0.0000000010000001f64);
+    }
+
+    #[test]
+    fn test_zero() {
+        assert_abs_diff_eq!(0.0f64, 0.0f64);
+        assert_abs_diff_eq!(0.0f64, -0.0f64);
+        assert_abs_diff_eq!(-0.0f64, -0.0f64);
+
+        assert_abs_diff_ne!(0.000000000000001f64, 0.0f64);
+        assert_abs_diff_ne!(0.0f64, 0.000000000000001f64);
+        assert_abs_diff_ne!(-0.000000000000001f64, 0.0f64);
+        assert_abs_diff_ne!(0.0f64, -0.000000000000001f64);
+    }
+
+    #[test]
+    fn test_epsilon() {
+        assert_abs_diff_eq!(0.0f64, 1e-40f64, epsilon = 1e-40f64);
+        assert_abs_diff_eq!(1e-40f64, 0.0f64, epsilon = 1e-40f64);
+        assert_abs_diff_eq!(0.0f64, -1e-40f64, epsilon = 1e-40f64);
+        assert_abs_diff_eq!(-1e-40f64, 0.0f64, epsilon = 1e-40f64);
+
+        assert_abs_diff_ne!(1e-40f64, 0.0f64, epsilon = 1e-41f64);
+        assert_abs_diff_ne!(0.0f64, 1e-40f64, epsilon = 1e-41f64);
+        assert_abs_diff_ne!(-1e-40f64, 0.0f64, epsilon = 1e-41f64);
+        assert_abs_diff_ne!(0.0f64, -1e-40f64, epsilon = 1e-41f64);
+    }
+
+
+    #[test]
+    fn test_max() {
+        assert_abs_diff_eq!(f64::MAX, f64::MAX);
+        assert_abs_diff_ne!(f64::MAX, -f64::MAX);
+        assert_abs_diff_ne!(-f64::MAX, f64::MAX);
+        assert_abs_diff_ne!(f64::MAX, f64::MAX / 2.0);
+        assert_abs_diff_ne!(f64::MAX, -f64::MAX / 2.0);
+        assert_abs_diff_ne!(-f64::MAX, f64::MAX / 2.0);
+    }
+
+    // NOTE: abs_diff_eq fails as numbers begin to get very large
+
+    // #[test]
+    // fn test_infinity() {
+    //     assert_abs_diff_eq!(f64::INFINITY, f64::INFINITY);
+    //     assert_abs_diff_eq!(f64::NEG_INFINITY, f64::NEG_INFINITY);
+    //     assert_abs_diff_ne!(f64::NEG_INFINITY, f64::INFINITY);
+    //     assert_abs_diff_eq!(f64::INFINITY, f64::MAX);
+    //     assert_abs_diff_eq!(f64::NEG_INFINITY, -f64::MAX);
+    // }
+
+    #[test]
+    fn test_nan() {
+        assert_abs_diff_ne!(f64::NAN, f64::NAN);
+
+        assert_abs_diff_ne!(f64::NAN, 0.0);
+        assert_abs_diff_ne!(-0.0, f64::NAN);
+        assert_abs_diff_ne!(f64::NAN, -0.0);
+        assert_abs_diff_ne!(0.0, f64::NAN);
+
+        assert_abs_diff_ne!(f64::NAN, f64::INFINITY);
+        assert_abs_diff_ne!(f64::INFINITY, f64::NAN);
+        assert_abs_diff_ne!(f64::NAN, f64::NEG_INFINITY);
+        assert_abs_diff_ne!(f64::NEG_INFINITY, f64::NAN);
+
+        assert_abs_diff_ne!(f64::NAN, f64::MAX);
+        assert_abs_diff_ne!(f64::MAX, f64::NAN);
+        assert_abs_diff_ne!(f64::NAN, -f64::MAX);
+        assert_abs_diff_ne!(-f64::MAX, f64::NAN);
+
+        assert_abs_diff_ne!(f64::NAN, f64::MIN_POSITIVE);
+        assert_abs_diff_ne!(f64::MIN_POSITIVE, f64::NAN);
+        assert_abs_diff_ne!(f64::NAN, -f64::MIN_POSITIVE);
+        assert_abs_diff_ne!(-f64::MIN_POSITIVE, f64::NAN);
+    }
+
+    #[test]
+    fn test_opposite_signs() {
+        assert_abs_diff_ne!(1.000000001f64, -1.0f64);
+        assert_abs_diff_ne!(-1.0f64, 1.000000001f64);
+        assert_abs_diff_ne!(-1.000000001f64, 1.0f64);
+        assert_abs_diff_ne!(1.0f64, -1.000000001f64);
+
+        assert_abs_diff_eq!(10.0 * f64::MIN_POSITIVE, 10.0 * -f64::MIN_POSITIVE);
+    }
+
+    #[test]
+    fn test_close_to_zero() {
+        assert_abs_diff_eq!(f64::MIN_POSITIVE, f64::MIN_POSITIVE);
+        assert_abs_diff_eq!(f64::MIN_POSITIVE, -f64::MIN_POSITIVE);
+        assert_abs_diff_eq!(-f64::MIN_POSITIVE, f64::MIN_POSITIVE);
+
+        assert_abs_diff_eq!(f64::MIN_POSITIVE, 0.0f64);
+        assert_abs_diff_eq!(0.0f64, f64::MIN_POSITIVE);
+        assert_abs_diff_eq!(-f64::MIN_POSITIVE, 0.0f64);
+        assert_abs_diff_eq!(0.0f64, -f64::MIN_POSITIVE);
+
+        assert_abs_diff_ne!(0.000000000000001f64, -f64::MIN_POSITIVE);
+        assert_abs_diff_ne!(0.000000000000001f64, f64::MIN_POSITIVE);
+        assert_abs_diff_ne!(f64::MIN_POSITIVE, 0.000000000000001f64);
+        assert_abs_diff_ne!(-f64::MIN_POSITIVE, 0.000000000000001f64);
+    }
+}

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -18,6 +18,18 @@
 extern crate approx;
 
 #[test]
+fn test_abs_diff_eq() {
+    let _: bool = abs_diff_eq!(1.0, 1.0);
+    let _: bool = abs_diff_eq!(1.0, 1.0, epsilon = 1.0);
+}
+
+#[test]
+fn test_abs_diff_ne() {
+    let _: bool = abs_diff_ne!(1.0, 1.0);
+    let _: bool = abs_diff_ne!(1.0, 1.0, epsilon = 1.0);
+}
+
+#[test]
 fn test_relative_eq() {
     let _: bool = relative_eq!(1.0, 1.0);
     let _: bool = relative_eq!(1.0, 1.0, epsilon = 1.0);


### PR DESCRIPTION
Closes #8.

The documentation could be a great deal better, especially given @Andlon's brilliantly in-depth answers on #8. We should definitely revisit it and give it the love it deserves. Other future things that might be interesting to explore is copying some design decisions from [the macros provided in rulinalg](https://docs.rs/rulinalg/0.4.2/rulinalg/macro.assert_matrix_eq.html).