### PR TITLE
Fix for single infinity argument to relative_eq

### DIFF
--- a/src/relative_eq.rs
+++ b/src/relative_eq.rs
@@ -57,6 +57,11 @@ macro_rules! impl_relative_eq {
                     return true;
                 }
 
+                // Handle remaining infinities
+                if $T::is_infinite(*self) || $T::is_infinite(*other) {
+                    return false;
+                }
+
                 let abs_diff = $T::abs(self - other);
 
                 // For when the numbers are really close together
@@ -66,11 +71,6 @@ macro_rules! impl_relative_eq {
 
                 let abs_self = $T::abs(*self);
                 let abs_other = $T::abs(*other);
-
-                // Handle oppsite infinities
-                if abs_self == abs_other && abs_diff == abs_self {
-                    return false;
-                }
 
                 let largest = if abs_other > abs_self { abs_other } else { abs_self };
 

--- a/tests/relative_eq.rs
+++ b/tests/relative_eq.rs
@@ -127,8 +127,6 @@ mod test_f32 {
         assert_relative_eq!(f32::INFINITY, f32::INFINITY);
         assert_relative_eq!(f32::NEG_INFINITY, f32::NEG_INFINITY);
         assert_relative_ne!(f32::NEG_INFINITY, f32::INFINITY);
-        assert_relative_eq!(f32::INFINITY, f32::MAX);
-        assert_relative_eq!(f32::NEG_INFINITY, -f32::MAX);
     }
 
     #[test]
@@ -295,8 +293,6 @@ mod test_f64 {
         assert_relative_eq!(f64::INFINITY, f64::INFINITY);
         assert_relative_eq!(f64::NEG_INFINITY, f64::NEG_INFINITY);
         assert_relative_ne!(f64::NEG_INFINITY, f64::INFINITY);
-        assert_relative_eq!(f64::INFINITY, f64::MAX);
-        assert_relative_eq!(f64::NEG_INFINITY, -f64::MAX);
     }
 
     #[test]


### PR DESCRIPTION
This changes behavior. Under a relatve_eq() test, MAX will no longer
approximately equal INFINITY, and similar for -MAX and NEG_INFINITY.
Thus the test cases for this were removed.

An ulps test could classify these as approx equal, but a relative
test could never do so without INFINITY being approx equal to
everything else.

Addresses #26