### PR TITLE
Remove Sized bounds where appropriate.

### DIFF
--- a/src/abs_diff_eq.rs
+++ b/src/abs_diff_eq.rs
@@ -87,7 +87,7 @@ impl_signed_abs_diff_eq!(f64, f64::EPSILON);
 // Derived implementations
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-impl<'a, T: AbsDiffEq> AbsDiffEq for &'a T {
+impl<'a, T: AbsDiffEq + ?Sized> AbsDiffEq for &'a T {
     type Epsilon = T::Epsilon;
 
     #[inline]
@@ -101,7 +101,7 @@ impl<'a, T: AbsDiffEq> AbsDiffEq for &'a T {
     }
 }
 
-impl<'a, T: AbsDiffEq> AbsDiffEq for &'a mut T {
+impl<'a, T: AbsDiffEq + ?Sized> AbsDiffEq for &'a mut T {
     type Epsilon = T::Epsilon;
 
     #[inline]
@@ -129,7 +129,7 @@ impl<T: AbsDiffEq + Copy> AbsDiffEq for cell::Cell<T> {
     }
 }
 
-impl<T: AbsDiffEq> AbsDiffEq for cell::RefCell<T> {
+impl<T: AbsDiffEq + ?Sized> AbsDiffEq for cell::RefCell<T> {
     type Epsilon = T::Epsilon;
 
     #[inline]

--- a/src/relative_eq.rs
+++ b/src/relative_eq.rs
@@ -89,7 +89,7 @@ impl_relative_eq!(f64, i64);
 // Derived implementations
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-impl<'a, T: RelativeEq> RelativeEq for &'a T {
+impl<'a, T: RelativeEq + ?Sized> RelativeEq for &'a T {
     #[inline]
     fn default_max_relative() -> T::Epsilon {
         T::default_max_relative()
@@ -101,7 +101,7 @@ impl<'a, T: RelativeEq> RelativeEq for &'a T {
     }
 }
 
-impl<'a, T: RelativeEq> RelativeEq for &'a mut T {
+impl<'a, T: RelativeEq + ?Sized> RelativeEq for &'a mut T {
     #[inline]
     fn default_max_relative() -> T::Epsilon {
         T::default_max_relative()
@@ -135,7 +135,7 @@ impl<T: RelativeEq + Copy> RelativeEq for cell::Cell<T> {
     }
 }
 
-impl<T: RelativeEq> RelativeEq for cell::RefCell<T> {
+impl<T: RelativeEq + ?Sized> RelativeEq for cell::RefCell<T> {
     #[inline]
     fn default_max_relative() -> T::Epsilon {
         T::default_max_relative()

--- a/src/ulps_eq.rs
+++ b/src/ulps_eq.rs
@@ -66,7 +66,7 @@ impl_ulps_eq!(f64, i64);
 // Derived implementations
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-impl<'a, T: UlpsEq> UlpsEq for &'a T {
+impl<'a, T: UlpsEq + ?Sized> UlpsEq for &'a T {
     #[inline]
     fn default_max_ulps() -> u32 {
         T::default_max_ulps()
@@ -78,7 +78,7 @@ impl<'a, T: UlpsEq> UlpsEq for &'a T {
     }
 }
 
-impl<'a, T: UlpsEq> UlpsEq for &'a mut T {
+impl<'a, T: UlpsEq + ?Sized> UlpsEq for &'a mut T {
     #[inline]
     fn default_max_ulps() -> u32 {
         T::default_max_ulps()
@@ -102,7 +102,7 @@ impl<T: UlpsEq + Copy> UlpsEq for cell::Cell<T> {
     }
 }
 
-impl<T: UlpsEq> UlpsEq for cell::RefCell<T> {
+impl<T: UlpsEq + ?Sized> UlpsEq for cell::RefCell<T> {
     #[inline]
     fn default_max_ulps() -> u32 {
         T::default_max_ulps()


### PR DESCRIPTION
For example `&[f64]` can't be `AbsDiffEq` because of this. Fixes #37.