### PR TITLE
Bump num complex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 
 rust:
+  - 1.20.0
   - nightly
   - beta
   - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache: cargo
 env:
   - CARGO_FEATURES=""
   - CARGO_FEATURES="std"
-  - CARGO_FEATURES="std use_complex"
+  - CARGO_FEATURES="std num-complex"
 
 matrix:
   allow_failures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "approx"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>"]
 license = "Apache-2.0"
 description = "Approximate floating point equality comparisons and assertions."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ use_complex = ["num-complex"]
 
 [dependencies]
 num-traits = { version = "0.2.0", default_features = false }
-num-complex = { version = "0.1.37", optional = true }
+num-complex = { version = "0.2.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,15 @@ keywords = [
     "float",
 ]
 
+[package.metadata.docs.rs]
+features = ["std", "num-complex"]
+
 [lib]
 name = "approx"
 
 [features]
 default = ["std"]
 std = []
-use_complex = ["num-complex"]
 
 [dependencies]
 num-traits = { version = "0.2.0", default_features = false }

--- a/src/abs_diff_eq.rs
+++ b/src/abs_diff_eq.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "use_complex")]
+#[cfg(feature = "num-complex")]
 use num_complex::Complex;
 #[cfg(not(feature = "std"))]
 use num_traits::float::FloatCore;
@@ -161,7 +161,7 @@ where
     }
 }
 
-#[cfg(feature = "use_complex")]
+#[cfg(feature = "num-complex")]
 impl<T: AbsDiffEq> AbsDiffEq for Complex<T>
 where
     T::Epsilon: Clone,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "use_complex")]
+#[cfg(feature = "num-complex")]
 extern crate num_complex;
 extern crate num_traits;
 

--- a/src/relative_eq.rs
+++ b/src/relative_eq.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "use_complex")]
+#[cfg(feature = "num-complex")]
 use num_complex::Complex;
 #[cfg(not(feature = "std"))]
 use num_traits::float::FloatCore;
@@ -169,7 +169,7 @@ where
     }
 }
 
-#[cfg(feature = "use_complex")]
+#[cfg(feature = "num-complex")]
 impl<T: RelativeEq> RelativeEq for Complex<T>
 where
     T::Epsilon: Clone,

--- a/src/ulps_eq.rs
+++ b/src/ulps_eq.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "use_complex")]
+#[cfg(feature = "num-complex")]
 use num_complex::Complex;
 #[cfg(not(feature = "std"))]
 use num_traits::float::FloatCore;
@@ -131,7 +131,7 @@ where
     }
 }
 
-#[cfg(feature = "use_complex")]
+#[cfg(feature = "num-complex")]
 impl<T: UlpsEq> UlpsEq for Complex<T>
 where
     T::Epsilon: Clone,

--- a/tests/abs_diff_eq.rs
+++ b/tests/abs_diff_eq.rs
@@ -391,7 +391,7 @@ mod test_slice {
     }
 }
 
-#[cfg(feature = "use_complex")]
+#[cfg(feature = "num-complex")]
 mod test_complex {
     extern crate num_complex;
     pub use self::num_complex::Complex;

--- a/tests/relative_eq.rs
+++ b/tests/relative_eq.rs
@@ -389,7 +389,7 @@ mod test_slice {
     }
 }
 
-#[cfg(feature = "use_complex")]
+#[cfg(feature = "num-complex")]
 mod test_complex {
     extern crate num_complex;
     pub use self::num_complex::Complex;

--- a/tests/ulps_eq.rs
+++ b/tests/ulps_eq.rs
@@ -387,7 +387,7 @@ mod test_slice {
     }
 }
 
-#[cfg(feature = "use_complex")]
+#[cfg(feature = "num-complex")]
 mod test_complex {
     extern crate num_complex;
     pub use self::num_complex::Complex;


### PR DESCRIPTION
This bumps `num-complex` to `v0.2.0`, and switches to using `num-complex` as a feature.