### PR TITLE
[WIP] Accept custom panic messages in `assert_*` macros

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -99,7 +99,24 @@ macro_rules! __assert_approx {
             );
         }
     }};
-    ($eq:ident, $given:expr, $expected:expr, $($opt:ident = $val:expr),+) => {{
+    ($eq:ident, $given:expr, $expected:expr; $($arg:tt)*) => {{
+        let (given, expected) = (&($given), &($expected));
+
+        if !$eq!(*given, *expected) {
+            panic!(
+"assert_{}!({}, {})
+
+    {}
+
+",
+                stringify!($eq),
+                stringify!($given),
+                stringify!($expected),
+                format_args!($($arg)*),
+            );
+        }
+    }};
+    ($eq:ident, $given:expr, $expected:expr $(, $opt:ident = $val:expr)+) => {{
         let (given, expected) = (&($given), &($expected));
 
         if !$eq!(*given, *expected, $($opt = $val),+) {
@@ -118,6 +135,24 @@ macro_rules! __assert_approx {
             );
         }
     }};
+    ($eq:ident, $given:expr, $expected:expr $(, $opt:ident = $val:expr)+; $($arg:tt)*) => {{
+        let (given, expected) = (&($given), &($expected));
+
+        if !$eq!(*given, *expected, $($opt = $val),+) {
+            panic!(
+"assert_{}!({}, {}, {})
+
+    {}
+
+",
+                stringify!($eq),
+                stringify!($given),
+                stringify!($expected),
+                stringify!($($opt = $val),+),
+                format_args!($($arg)*),
+            );
+        }
+    }};
 }
 
 /// An assertion that delegates to `abs_diff_eq!`, and panics with a helpful error on failure.
@@ -126,8 +161,8 @@ macro_rules! assert_abs_diff_eq {
     ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*) => {
         __assert_approx!(abs_diff_eq, $given, $expected $(, $opt = $val)*)
     };
-    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*,) => {
-        __assert_approx!(abs_diff_eq, $given, $expected $(, $opt = $val)*)
+    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*; $($arg:tt)*) => {
+        __assert_approx!(abs_diff_eq, $given, $expected $(, $opt = $val)*; $($arg)*)
     };
 }
 
@@ -137,8 +172,8 @@ macro_rules! assert_abs_diff_ne {
     ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*) => {
         __assert_approx!(abs_diff_ne, $given, $expected $(, $opt = $val)*)
     };
-    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*,) => {
-        __assert_approx!(abs_diff_ne, $given, $expected $(, $opt = $val)*)
+    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*; $($arg:tt)*) => {
+        __assert_approx!(abs_diff_ne, $given, $expected $(, $opt = $val)*; $($arg)*)
     };
 }
 
@@ -148,8 +183,8 @@ macro_rules! assert_relative_eq {
     ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*) => {
         __assert_approx!(relative_eq, $given, $expected $(, $opt = $val)*)
     };
-    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*,) => {
-        __assert_approx!(relative_eq, $given, $expected $(, $opt = $val)*)
+    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*; $($arg:tt)*) => {
+        __assert_approx!(relative_eq, $given, $expected $(, $opt = $val)*; $($arg)*)
     };
 }
 
@@ -159,8 +194,8 @@ macro_rules! assert_relative_ne {
     ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*) => {
         __assert_approx!(relative_ne, $given, $expected $(, $opt = $val)*)
     };
-    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*,) => {
-        __assert_approx!(relative_ne, $given, $expected $(, $opt = $val)*)
+    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*; $($arg:tt)*) => {
+        __assert_approx!(relative_ne, $given, $expected $(, $opt = $val)*; $($arg)*)
     };
 }
 
@@ -170,8 +205,8 @@ macro_rules! assert_ulps_eq {
     ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*) => {
         __assert_approx!(ulps_eq, $given, $expected $(, $opt = $val)*)
     };
-    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*,) => {
-        __assert_approx!(ulps_eq, $given, $expected $(, $opt = $val)*)
+    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*; $($arg:tt)*) => {
+        __assert_approx!(ulps_eq, $given, $expected $(, $opt = $val)*); $($arg)*
     };
 }
 
@@ -181,7 +216,7 @@ macro_rules! assert_ulps_ne {
     ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*) => {
         __assert_approx!(ulps_ne, $given, $expected $(, $opt = $val)*)
     };
-    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*,) => {
-        __assert_approx!(ulps_ne, $given, $expected $(, $opt = $val)*)
+    ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*; $($arg:tt)*) => {
+        __assert_approx!(ulps_ne, $given, $expected $(, $opt = $val)*); $($arg)*
     };
 }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -96,3 +96,20 @@ fn test_ulps_ne_trailing_commas() {
     let _: bool = ulps_ne!(1.0, 1.0,);
     let _: bool = ulps_ne!(1.0, 1.0, epsilon = 1.0, max_ulps = 1,);
 }
+
+#[test]
+#[should_panic]
+fn test_panic_message_1() {
+    let x = 1.0f32;
+    let y = 2.0f32;
+    assert_abs_diff_eq!(1.0f32, 2.0f32; "Should panic. x = {:?}, y = {:?}", x, y);
+}
+
+#[test]
+#[should_panic]
+fn test_panic_message_2() {
+    let x = 0.0f32;
+    let y = 1e-40f32;
+    let epsilon = 0.0f32;
+    assert_abs_diff_eq!(x, y, epsilon = epsilon; "Should panic. x = {:?}, y = {:?}, epsilon: {:?}", x, y, epsilon);
+}


### PR DESCRIPTION
Due to parsing ambiguities arising from adding a second repeating pattern, I took the approach of separating the panic message args from the rest of the macro args with a `;`, like so:

```rust
($given:expr, $expected:expr $(, $opt:ident = $val:expr)*; $($arg:tt)*)
                                                        ^^^
```

which allows us to do this:

```rust
assert_abs_diff_eq!(x, y, epsilon = epsilon; "Should panic. x = {:?}, y = {:?},
    epsilon: {:?}", x, y, epsilon);
```

It feels rather hacky though, and deviates from how Rust macros behave. Throwing this up to see if you've got any ideas on how to tackle this.