### PR TITLE
Export macros that call other macros with `local_inner_macros` attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
     - rust: nightly
 
 before_script:
+  - if [ "$TRAVIS_RUST_VERSION" == "1.20.0" ]; then rm -f tests/macro_import.rs; fi
   - cargo build --verbose
 
 script:

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -121,7 +121,7 @@ macro_rules! __assert_approx {
 }
 
 /// An assertion that delegates to `abs_diff_eq!`, and panics with a helpful error on failure.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! assert_abs_diff_eq {
     ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*) => {
         __assert_approx!(abs_diff_eq, $given, $expected $(, $opt = $val)*)
@@ -132,7 +132,7 @@ macro_rules! assert_abs_diff_eq {
 }
 
 /// An assertion that delegates to `abs_diff_ne!`, and panics with a helpful error on failure.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! assert_abs_diff_ne {
     ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*) => {
         __assert_approx!(abs_diff_ne, $given, $expected $(, $opt = $val)*)
@@ -143,7 +143,7 @@ macro_rules! assert_abs_diff_ne {
 }
 
 /// An assertion that delegates to `relative_eq!`, and panics with a helpful error on failure.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! assert_relative_eq {
     ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*) => {
         __assert_approx!(relative_eq, $given, $expected $(, $opt = $val)*)
@@ -154,7 +154,7 @@ macro_rules! assert_relative_eq {
 }
 
 /// An assertion that delegates to `relative_ne!`, and panics with a helpful error on failure.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! assert_relative_ne {
     ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*) => {
         __assert_approx!(relative_ne, $given, $expected $(, $opt = $val)*)
@@ -165,7 +165,7 @@ macro_rules! assert_relative_ne {
 }
 
 /// An assertion that delegates to `ulps_eq!`, and panics with a helpful error on failure.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! assert_ulps_eq {
     ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*) => {
         __assert_approx!(ulps_eq, $given, $expected $(, $opt = $val)*)
@@ -176,7 +176,7 @@ macro_rules! assert_ulps_eq {
 }
 
 /// An assertion that delegates to `ulps_ne!`, and panics with a helpful error on failure.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! assert_ulps_ne {
     ($given:expr, $expected:expr $(, $opt:ident = $val:expr)*) => {
         __assert_approx!(ulps_ne, $given, $expected $(, $opt = $val)*)

--- a/tests/macro_import.rs
+++ b/tests/macro_import.rs
@@ -1,0 +1,18 @@
+extern crate approx;
+
+mod test_macro_import {
+    use approx::{
+        assert_abs_diff_eq, assert_abs_diff_ne, assert_relative_eq, assert_relative_ne,
+        assert_ulps_eq, assert_ulps_ne,
+    };
+
+    #[test]
+    fn test() {
+        assert_abs_diff_eq!(1.0f32, 1.0f32);
+        assert_abs_diff_ne!(1.0f32, 2.0f32);
+        assert_relative_eq!(1.0f32, 1.0f32);
+        assert_relative_ne!(1.0f32, 2.0f32);
+        assert_ulps_eq!(1.0f32, 1.0f32);
+        assert_ulps_ne!(1.0f32, 2.0f32);
+    }
+}


### PR DESCRIPTION
Fixes #42.

This fixes an issue when using Rust >= 1.30.0 where importing a macro that invokes other macros does not bring the dependent macros into scope.