### PR TITLE
mark eq and ne fns as #[must_use]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 rust:
-  - 1.20.0
+  - 1.27.2
   - nightly
   - beta
   - stable
@@ -18,7 +18,7 @@ matrix:
     - rust: nightly
 
 before_script:
-  - if [ "$TRAVIS_RUST_VERSION" == "1.20.0" ]; then rm -f tests/macro_import.rs; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "1.27.2" ]; then rm -f tests/macro_import.rs; fi
   - cargo build --verbose
 
 script:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,12 +223,14 @@ where
 
     /// Peform the equality comparison
     #[inline]
+    #[must_use]
     pub fn eq(self, lhs: &A, rhs: &B) -> bool {
         A::abs_diff_eq(lhs, rhs, self.epsilon)
     }
 
     /// Peform the inequality comparison
     #[inline]
+    #[must_use]
     pub fn ne(self, lhs: &A, rhs: &B) -> bool {
         A::abs_diff_ne(lhs, rhs, self.epsilon)
     }
@@ -299,12 +301,14 @@ where
 
     /// Peform the equality comparison
     #[inline]
+    #[must_use]
     pub fn eq(self, lhs: &A, rhs: &B) -> bool {
         A::relative_eq(lhs, rhs, self.epsilon, self.max_relative)
     }
 
     /// Peform the inequality comparison
     #[inline]
+    #[must_use]
     pub fn ne(self, lhs: &A, rhs: &B) -> bool {
         A::relative_ne(lhs, rhs, self.epsilon, self.max_relative)
     }
@@ -372,12 +376,14 @@ where
 
     /// Peform the equality comparison
     #[inline]
+    #[must_use]
     pub fn eq(self, lhs: &A, rhs: &B) -> bool {
         A::ulps_eq(lhs, rhs, self.epsilon, self.max_ulps)
     }
 
     /// Peform the inequality comparison
     #[inline]
+    #[must_use]
     pub fn ne(self, lhs: &A, rhs: &B) -> bool {
         A::ulps_ne(lhs, rhs, self.epsilon, self.max_ulps)
     }


### PR DESCRIPTION
A couple of times I have found myself writing:

```rs

#[test]
fn test_something() {
  approx::relative_eq!(something, something_else);
}

```

Obviously this test always passes because the macro expands to a function call returning a `bool`. This then means I have tests that _should_ be failing but instead are passing.

This pull request marks `[AbsDiff|Relative|Ulps]::[eq|ne]` with the `must_use` attribute. Because this attribute is only supported on functions since the `1.27.0` release I have bumped the MSRV accordingly. If this feature isn't worth bumping the MSRV I completely understand. Thank you for this very useful library!