### PR TITLE
Implement traits for `Option` and `Result`

### DIFF
--- a/src/abs_diff_eq.rs
+++ b/src/abs_diff_eq.rs
@@ -90,6 +90,42 @@ impl_signed_abs_diff_eq!(f64, f64::EPSILON);
 // Derived implementations
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
+impl<T: AbsDiffEq> AbsDiffEq for Option<T> {
+    type Epsilon = T::Epsilon;
+
+    #[inline]
+    fn default_epsilon() -> T::Epsilon {
+        T::default_epsilon()
+    }
+
+    #[inline]
+    fn abs_diff_eq(&self, other: &Option<T>, epsilon: T::Epsilon) -> bool {
+        match (self, other) {
+            (Some(a), Some(b)) => T::abs_diff_eq(a, b, epsilon),
+            (None, None) => true,
+            _ => false,
+        }
+    }
+}
+
+impl<T: AbsDiffEq, E: AbsDiffEq> AbsDiffEq for Result<T, E> {
+    type Epsilon = (T::Epsilon, E::Epsilon);
+
+    #[inline]
+    fn default_epsilon() -> (T::Epsilon, E::Epsilon) {
+        (T::default_epsilon(), E::default_epsilon())
+    }
+
+    #[inline]
+    fn abs_diff_eq(&self, other: &Result<T, E>, epsilon: (T::Epsilon, E::Epsilon)) -> bool {
+        match (self, other) {
+            (Ok(a), Ok(b)) => T::abs_diff_eq(a, b, epsilon.0),
+            (Err(a), Err(b)) => E::abs_diff_eq(a, b, epsilon.1),
+            _ => false,
+        }
+    }
+}
+
 impl<'a, T: AbsDiffEq + ?Sized> AbsDiffEq for &'a T {
     type Epsilon = T::Epsilon;
 

--- a/src/relative_eq.rs
+++ b/src/relative_eq.rs
@@ -92,6 +92,48 @@ impl_relative_eq!(f64, i64);
 // Derived implementations
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
+impl<T: RelativeEq> RelativeEq for Option<T> {
+    #[inline]
+    fn default_max_relative() -> T::Epsilon {
+        T::default_max_relative()
+    }
+
+    #[inline]
+    fn relative_eq(
+        &self,
+        other: &Option<T>,
+        epsilon: T::Epsilon,
+        max_relative: T::Epsilon,
+    ) -> bool {
+        match (self, other) {
+            (Some(a), Some(b)) => T::relative_eq(a, b, epsilon, max_relative),
+            (None, None) => true,
+            _ => false,
+        }
+    }
+}
+
+impl<T: RelativeEq, E: RelativeEq> RelativeEq for Result<T, E> {
+    #[inline]
+    fn default_max_relative() -> (T::Epsilon, E::Epsilon) {
+        (T::default_max_relative(), E::default_max_relative())
+    }
+
+    #[inline]
+    fn relative_eq(
+        &self,
+        other: &Result<T, E>,
+        epsilon: (T::Epsilon, E::Epsilon),
+        max_relative: (T::Epsilon, E::Epsilon),
+    ) -> bool {
+        match (self, other) {
+            (Ok(a), Ok(b)) => T::relative_eq(a, b, epsilon.0, max_relative.0),
+            (Err(a), Err(b)) => E::relative_eq(a, b, epsilon.1, max_relative.1),
+            _ => false,
+        }
+    }
+}
+
 impl<'a, T: RelativeEq + ?Sized> RelativeEq for &'a T {
     #[inline]
     fn default_max_relative() -> T::Epsilon {

--- a/src/ulps_eq.rs
+++ b/src/ulps_eq.rs
@@ -69,6 +69,43 @@ impl_ulps_eq!(f64, i64);
 // Derived implementations
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
+impl<T: UlpsEq> UlpsEq for Option<T> {
+    #[inline]
+    fn default_max_ulps() -> u32 {
+        T::default_max_ulps()
+    }
+
+    #[inline]
+    fn ulps_eq(&self, other: &Option<T>, epsilon: T::Epsilon, max_ulps: u32) -> bool {
+        match (self, other) {
+            (Some(a), Some(b)) => T::ulps_eq(a, b, epsilon, max_ulps),
+            (None, None) => true,
+            _ => false,
+        }
+    }
+}
+
+impl<T: UlpsEq, E: UlpsEq> UlpsEq for Result<T, E> {
+    #[inline]
+    fn default_max_ulps() -> u32 {
+        T::default_max_ulps().max(E::default_max_ulps())
+    }
+
+    #[inline]
+    fn ulps_eq(
+        &self,
+        other: &Result<T, E>,
+        epsilon: (T::Epsilon, E::Epsilon),
+        max_ulps: u32,
+    ) -> bool {
+        match (self, other) {
+            (Ok(a), Ok(b)) => T::ulps_eq(a, b, epsilon.0, max_ulps),
+            (Err(a), Err(b)) => E::ulps_eq(a, b, epsilon.1, max_ulps),
+            _ => false,
+        }
+    }
+}
+
 impl<'a, T: UlpsEq + ?Sized> UlpsEq for &'a T {
     #[inline]
     fn default_max_ulps() -> u32 {

--- a/tests/abs_diff_eq.rs
+++ b/tests/abs_diff_eq.rs
@@ -355,6 +355,54 @@ mod test_f64 {
     }
 }
 
+mod test_option {
+    mod test_f32 {
+        #[test]
+        fn test_basic() {
+            assert_abs_diff_eq!(Some(1.0f32), Some(1.0f32));
+
+            assert_abs_diff_ne!(Some(1.0f32), Some(2.0f32));
+            assert_abs_diff_ne!(Some(1.0f32), None);
+        }
+    }
+
+    mod test_f64 {
+        #[test]
+        fn test_basic() {
+            assert_abs_diff_eq!(Some(1.0f64), Some(1.0f64));
+
+            assert_abs_diff_ne!(Some(1.0f64), Some(2.0f64));
+            assert_abs_diff_ne!(Some(1.0f64), None);
+        }
+    }
+}
+
+mod test_result {
+    mod test_f32 {
+        #[test]
+        fn test_basic() {
+            assert_abs_diff_eq!(Ok::<f32, f32>(1.0f32), Ok(1.0f32));
+            assert_abs_diff_eq!(Err::<f32, f32>(1.0f32), Err(1.0f32));
+
+            assert_abs_diff_ne!(Ok::<f32, f32>(1.0f32), Ok(2.0f32));
+            assert_abs_diff_ne!(Ok::<f32, f32>(1.0f32), Err(1.0f32));
+            assert_abs_diff_ne!(Err::<f32, f32>(1.0f32), Err(2.0f32));
+        }
+    }
+
+    mod test_f64 {
+        #[test]
+        fn test_basic() {
+            assert_abs_diff_eq!(Ok::<f64, f64>(1.0f64), Ok(1.0f64));
+            assert_abs_diff_eq!(Err::<f64, f64>(1.0f64), Err(1.0f64));
+
+            assert_abs_diff_ne!(Ok::<f64, f64>(1.0f64), Ok(2.0f64));
+            assert_abs_diff_ne!(Ok::<f64, f64>(1.0f64), Err(1.0f64));
+            assert_abs_diff_ne!(Err::<f64, f64>(1.0f64), Err(2.0f64));
+        }
+    }
+}
+
 mod test_ref {
     mod test_f32 {
         #[test]

--- a/tests/relative_eq.rs
+++ b/tests/relative_eq.rs
@@ -353,6 +353,54 @@ mod test_f64 {
     }
 }
 
+mod test_option {
+    mod test_f32 {
+        #[test]
+        fn test_basic() {
+            assert_relative_eq!(Some(1.0f32), Some(1.0f32));
+
+            assert_relative_ne!(Some(1.0f32), Some(2.0f32));
+            assert_relative_ne!(Some(1.0f32), None);
+        }
+    }
+
+    mod test_f64 {
+        #[test]
+        fn test_basic() {
+            assert_relative_eq!(Some(1.0f64), Some(1.0f64));
+
+            assert_relative_ne!(Some(1.0f64), Some(2.0f64));
+            assert_relative_ne!(Some(1.0f64), None);
+        }
+    }
+}
+
+mod test_result {
+    mod test_f32 {
+        #[test]
+        fn test_basic() {
+            assert_relative_eq!(Ok::<f32, f32>(1.0f32), Ok(1.0f32));
+            assert_relative_eq!(Err::<f32, f32>(1.0f32), Err(1.0f32));
+
+            assert_relative_ne!(Ok::<f32, f32>(1.0f32), Ok(2.0f32));
+            assert_relative_ne!(Ok::<f32, f32>(1.0f32), Err(1.0f32));
+            assert_relative_ne!(Err::<f32, f32>(1.0f32), Err(2.0f32));
+        }
+    }
+
+    mod test_f64 {
+        #[test]
+        fn test_basic() {
+            assert_relative_eq!(Ok::<f64, f64>(1.0f64), Ok(1.0f64));
+            assert_relative_eq!(Err::<f64, f64>(1.0f64), Err(1.0f64));
+
+            assert_relative_ne!(Ok::<f64, f64>(1.0f64), Ok(2.0f64));
+            assert_relative_ne!(Ok::<f64, f64>(1.0f64), Err(1.0f64));
+            assert_relative_ne!(Err::<f64, f64>(1.0f64), Err(2.0f64));
+        }
+    }
+}
+
 mod test_ref {
     mod test_f32 {
         #[test]

--- a/tests/ulps_eq.rs
+++ b/tests/ulps_eq.rs
@@ -351,6 +351,54 @@ mod test_f64 {
     }
 }
 
+mod test_option {
+    mod test_f32 {
+        #[test]
+        fn test_basic() {
+            assert_ulps_eq!(Some(1.0f32), Some(1.0f32));
+
+            assert_ulps_ne!(Some(1.0f32), Some(2.0f32));
+            assert_ulps_ne!(Some(1.0f32), None);
+        }
+    }
+
+    mod test_f64 {
+        #[test]
+        fn test_basic() {
+            assert_ulps_eq!(Some(1.0f64), Some(1.0f64));
+
+            assert_ulps_ne!(Some(1.0f64), Some(2.0f64));
+            assert_ulps_ne!(Some(1.0f64), None);
+        }
+    }
+}
+
+mod test_result {
+    mod test_f32 {
+        #[test]
+        fn test_basic() {
+            assert_ulps_eq!(Ok::<f32, f32>(1.0f32), Ok(1.0f32));
+            assert_ulps_eq!(Err::<f32, f32>(1.0f32), Err(1.0f32));
+
+            assert_ulps_ne!(Ok::<f32, f32>(1.0f32), Ok(2.0f32));
+            assert_ulps_ne!(Ok::<f32, f32>(1.0f32), Err(1.0f32));
+            assert_ulps_ne!(Err::<f32, f32>(1.0f32), Err(2.0f32));
+        }
+    }
+
+    mod test_f64 {
+        #[test]
+        fn test_basic() {
+            assert_ulps_eq!(Ok::<f64, f64>(1.0f64), Ok(1.0f64));
+            assert_ulps_eq!(Err::<f64, f64>(1.0f64), Err(1.0f64));
+
+            assert_ulps_ne!(Ok::<f64, f64>(1.0f64), Ok(2.0f64));
+            assert_ulps_ne!(Ok::<f64, f64>(1.0f64), Err(1.0f64));
+            assert_ulps_ne!(Err::<f64, f64>(1.0f64), Err(2.0f64));
+        }
+    }
+}
+
 mod test_ref {
     mod test_f32 {
         #[test]


### PR DESCRIPTION
Values of types `Option` and `Result` are frequently checked for equality in testing, but `approx` does not currently implement its traits on these types. This PR aims to do just that.

For `Result<T, E>` I have opted to require the given trait on both `T` and `E`, so that the error can also contain approximately comparable values. I'm not entirely sure about this decision, however, so I would appreciate your input. The downside of this approach is that all error types are also forced to implement the given trait, which might be asking too much of the users of this library - especially since there is no easy way (e.g. `#[derive(...)]`) to do it automatically.

It's worth noting that `(Result<T, E> as UlpsEq)::default_max_ulps` returns the maximum tolerance of `T` and `E`. This is because the return type cannot be a tuple (unlike `AbsDiffEq`), and it seemed reasonable to allow the greater value. If anybody has a better idea - that doesn't involve breaking changes -, please let me know.

I can separate the implementations of `Option` and `Result` into separate PRs if necessary.