### PR TITLE
Remove the use of std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,7 @@ features = ["std", "num-complex"]
 name = "approx"
 
 [features]
-default = ["std"]
-std = []
+default = []
 
 [dependencies]
 num-traits = { version = "0.2.0", default_features = false }

--- a/src/abs_diff_eq.rs
+++ b/src/abs_diff_eq.rs
@@ -1,8 +1,6 @@
+use core::cell;
 #[cfg(feature = "num-complex")]
 use num_complex::Complex;
-#[cfg(not(feature = "std"))]
-use num_traits::float::FloatCore;
-use std::{cell, f32, f64};
 
 /// Equality that is defined using the absolute difference of two numbers.
 pub trait AbsDiffEq<Rhs = Self>: PartialEq<Rhs>
@@ -71,7 +69,9 @@ macro_rules! impl_signed_abs_diff_eq {
             }
 
             #[inline]
+            #[allow(unused_imports)]
             fn abs_diff_eq(&self, other: &$T, epsilon: $T) -> bool {
+                use num_traits::float::FloatCore;
                 $T::abs(self - other) <= epsilon
             }
         }
@@ -180,6 +180,6 @@ where
     #[inline]
     fn abs_diff_eq(&self, other: &Complex<T>, epsilon: T::Epsilon) -> bool {
         T::abs_diff_eq(&self.re, &other.re, epsilon.clone())
-            && T::abs_diff_eq(&self.im, &other.im, epsilon.clone())
+            && T::abs_diff_eq(&self.im, &other.im, epsilon)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! #[macro_use]
 //! extern crate approx;
 //!
-//! use std::f64;
+//! use core::f64;
 //!
 //! # fn main() {
 //! abs_diff_eq!(1.0, 1.0);
@@ -154,14 +154,12 @@
 //! - [What Every Computer Scientist Should Know About Floating-Point Arithmetic](
 //!   https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html)
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+#![allow(clippy::transmute_float_to_int)]
 
 #[cfg(feature = "num-complex")]
 extern crate num_complex;
 extern crate num_traits;
-
-#[cfg(not(feature = "std"))]
-use core as std;
 
 mod abs_diff_eq;
 mod relative_eq;
@@ -182,7 +180,7 @@ pub use ulps_eq::UlpsEq;
 /// # Example
 ///
 /// ```rust
-/// use std::f64;
+/// use core::f64;
 /// use approx::AbsDiff;
 ///
 /// AbsDiff::default().eq(&1.0, &1.0);
@@ -218,7 +216,7 @@ where
     /// Replace the epsilon value with the one specified.
     #[inline]
     pub fn epsilon(self, epsilon: A::Epsilon) -> AbsDiff<A, B> {
-        AbsDiff { epsilon, ..self }
+        AbsDiff { epsilon }
     }
 
     /// Peform the equality comparison
@@ -245,7 +243,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// use std::f64;
+/// use core::f64;
 /// use approx::Relative;
 ///
 /// Relative::default().eq(&1.0, &1.0);
@@ -323,7 +321,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// use std::f64;
+/// use core::f64;
 /// use approx::Ulps;
 ///
 /// Ulps::default().eq(&1.0, &1.0);

--- a/src/relative_eq.rs
+++ b/src/relative_eq.rs
@@ -1,9 +1,6 @@
+use core::{cell, f32, f64};
 #[cfg(feature = "num-complex")]
 use num_complex::Complex;
-#[cfg(not(feature = "std"))]
-use num_traits::float::FloatCore;
-use std::{cell, f32, f64};
-
 use AbsDiffEq;
 
 /// Equality comparisons between two numbers using both the absolute difference and
@@ -18,12 +15,8 @@ where
     fn default_max_relative() -> Self::Epsilon;
 
     /// A test for equality that uses a relative comparison if the values are far apart.
-    fn relative_eq(
-        &self,
-        other: &Rhs,
-        epsilon: Self::Epsilon,
-        max_relative: Self::Epsilon,
-    ) -> bool;
+    fn relative_eq(&self, other: &Rhs, epsilon: Self::Epsilon, max_relative: Self::Epsilon)
+        -> bool;
 
     /// The inverse of [`RelativeEq::relative_eq`].
     fn relative_ne(
@@ -51,7 +44,9 @@ macro_rules! impl_relative_eq {
             }
 
             #[inline]
+            #[allow(unused_imports)]
             fn relative_eq(&self, other: &$T, epsilon: $T, max_relative: $T) -> bool {
+                use num_traits::float::FloatCore;
                 // Handle same infinities
                 if self == other {
                     return true;
@@ -191,6 +186,6 @@ where
         max_relative: T::Epsilon,
     ) -> bool {
         T::relative_eq(&self.re, &other.re, epsilon.clone(), max_relative.clone())
-            && T::relative_eq(&self.im, &other.im, epsilon.clone(), max_relative.clone())
+            && T::relative_eq(&self.im, &other.im, epsilon, max_relative)
     }
 }

--- a/src/ulps_eq.rs
+++ b/src/ulps_eq.rs
@@ -1,8 +1,7 @@
+use core::{cell, mem};
 #[cfg(feature = "num-complex")]
 use num_complex::Complex;
-#[cfg(not(feature = "std"))]
-use num_traits::float::FloatCore;
-use std::{cell, mem};
+use num_traits::Signed;
 
 use AbsDiffEq;
 
@@ -131,7 +130,7 @@ where
     fn ulps_eq(&self, other: &[B], epsilon: A::Epsilon, max_ulps: u32) -> bool {
         self.len() == other.len()
             && Iterator::zip(self.iter(), other)
-                .all(|(x, y)| A::ulps_eq(x, y, epsilon.clone(), max_ulps.clone()))
+                .all(|(x, y)| A::ulps_eq(x, y, epsilon.clone(), max_ulps))
     }
 }
 
@@ -148,6 +147,6 @@ where
     #[inline]
     fn ulps_eq(&self, other: &Complex<T>, epsilon: T::Epsilon, max_ulps: u32) -> bool {
         T::ulps_eq(&self.re, &other.re, epsilon.clone(), max_ulps)
-            && T::ulps_eq(&self.im, &other.im, epsilon.clone(), max_ulps)
+            && T::ulps_eq(&self.im, &other.im, epsilon, max_ulps)
     }
 }

--- a/tests/abs_diff_eq.rs
+++ b/tests/abs_diff_eq.rs
@@ -14,12 +14,13 @@
 
 // Test cases derived from:
 // https://github.com/Pybonacci/puntoflotante.org/blob/master/content/errors/NearlyEqualsTest.java
+#![no_std]
 
 #[macro_use]
 extern crate approx;
 
 mod test_f32 {
-    use std::f32;
+    use core::f32;
 
     #[test]
     fn test_basic() {
@@ -188,7 +189,7 @@ mod test_f32 {
 
 #[cfg(test)]
 mod test_f64 {
-    use std::f64;
+    use core::f64;
 
     #[test]
     fn test_basic() {

--- a/tests/relative_eq.rs
+++ b/tests/relative_eq.rs
@@ -14,12 +14,13 @@
 
 // Test cases derived from:
 // https://github.com/Pybonacci/puntoflotante.org/blob/master/content/errors/NearlyEqualsTest.java
+#![no_std]
 
 #[macro_use]
 extern crate approx;
 
 mod test_f32 {
-    use std::f32;
+    use core::f32;
 
     #[test]
     fn test_basic() {
@@ -190,7 +191,7 @@ mod test_f32 {
 
 #[cfg(test)]
 mod test_f64 {
-    use std::f64;
+    use core::f64;
 
     #[test]
     fn test_basic() {

--- a/tests/ulps_eq.rs
+++ b/tests/ulps_eq.rs
@@ -14,12 +14,13 @@
 
 // Test cases derived from:
 // https://github.com/Pybonacci/puntoflotante.org/blob/master/content/errors/NearlyEqualsTest.java
+#![no_std]
 
 #[macro_use]
 extern crate approx;
 
 mod test_f32 {
-    use std::f32;
+    use core::f32;
 
     #[test]
     fn test_basic() {
@@ -186,7 +187,7 @@ mod test_f32 {
 
 #[cfg(test)]
 mod test_f64 {
-    use std::f64;
+    use core::f64;
 
     #[test]
     fn test_basic() {


### PR DESCRIPTION
Fixes #62 
Allows the use of std as a feature which doesn't do anything
Also fixes other lints suggested by clippy