### PR TITLE
Add impls for Vec

### DIFF
--- a/src/abs_diff_eq.rs
+++ b/src/abs_diff_eq.rs
@@ -165,6 +165,24 @@ where
     }
 }
 
+impl<A, B> AbsDiffEq<Vec<B>> for Vec<A>
+    where
+        A: AbsDiffEq<B>,
+        A::Epsilon: Clone,
+{
+    type Epsilon = A::Epsilon;
+
+    #[inline]
+    fn default_epsilon() -> A::Epsilon {
+        A::default_epsilon()
+    }
+
+    #[inline]
+    fn abs_diff_eq(&self, other: &Vec<B>, epsilon: A::Epsilon) -> bool {
+        self.as_slice().abs_diff_eq(other.as_slice(), epsilon)
+    }
+}
+
 #[cfg(feature = "num-complex")]
 impl<T: AbsDiffEq> AbsDiffEq for Complex<T>
 where

--- a/src/relative_eq.rs
+++ b/src/relative_eq.rs
@@ -173,6 +173,22 @@ where
     }
 }
 
+impl<A, B> RelativeEq<Vec<B>> for Vec<A>
+    where
+        A: RelativeEq<B>,
+        A::Epsilon: Clone,
+{
+    #[inline]
+    fn default_max_relative() -> A::Epsilon {
+        A::default_max_relative()
+    }
+
+    #[inline]
+    fn relative_eq(&self, other: &Vec<B>, epsilon: A::Epsilon, max_relative: A::Epsilon) -> bool {
+        self.as_slice().relative_eq(other.as_slice(), epsilon, max_relative)
+    }
+}
+
 #[cfg(feature = "num-complex")]
 impl<T: RelativeEq> RelativeEq for Complex<T>
 where

--- a/src/ulps_eq.rs
+++ b/src/ulps_eq.rs
@@ -135,6 +135,22 @@ where
     }
 }
 
+impl<A, B> UlpsEq<Vec<B>> for Vec<A>
+    where
+        A: UlpsEq<B>,
+        A::Epsilon: Clone,
+{
+    #[inline]
+    fn default_max_ulps() -> u32 {
+        A::default_max_ulps()
+    }
+
+    #[inline]
+    fn ulps_eq(&self, other: &Vec<B>, epsilon: A::Epsilon, max_ulps: u32) -> bool {
+        self.as_slice().ulps_eq(other.as_slice(), epsilon, max_ulps)
+    }
+}
+
 #[cfg(feature = "num-complex")]
 impl<T: UlpsEq> UlpsEq for Complex<T>
 where

--- a/tests/abs_diff_eq.rs
+++ b/tests/abs_diff_eq.rs
@@ -391,6 +391,24 @@ mod test_slice {
     }
 }
 
+mod test_vec {
+    mod test_f32 {
+        #[test]
+        fn test_basic() {
+            assert_abs_diff_eq!(vec![1.0f32, 2.0f32], vec![1.0f32, 2.0f32]);
+            assert_abs_diff_ne!(vec![1.0f32, 2.0f32], vec![2.0f32, 1.0f32]);
+        }
+    }
+
+    mod test_f64 {
+        #[test]
+        fn test_basic() {
+            assert_abs_diff_eq!(vec![1.0f64, 2.0f64], vec![1.0f64, 2.0f64]);
+            assert_abs_diff_ne!(vec![1.0f64, 2.0f64], vec![2.0f64, 1.0f64]);
+        }
+    }
+}
+
 #[cfg(feature = "num-complex")]
 mod test_complex {
     extern crate num_complex;

--- a/tests/relative_eq.rs
+++ b/tests/relative_eq.rs
@@ -389,6 +389,24 @@ mod test_slice {
     }
 }
 
+mod test_vec {
+    mod test_f32 {
+        #[test]
+        fn test_basic() {
+            assert_relative_eq!(vec![1.0f32, 2.0f32], vec![1.0f32, 2.0f32]);
+            assert_relative_ne!(vec![1.0f32, 2.0f32], vec![2.0f32, 1.0f32]);
+        }
+    }
+
+    mod test_f64 {
+        #[test]
+        fn test_basic() {
+            assert_relative_eq!(vec![1.0f64, 2.0f64], vec![1.0f64, 2.0f64]);
+            assert_relative_ne!(vec![1.0f64, 2.0f64], vec![2.0f64, 1.0f64]);
+        }
+    }
+}
+
 #[cfg(feature = "num-complex")]
 mod test_complex {
     extern crate num_complex;

--- a/tests/ulps_eq.rs
+++ b/tests/ulps_eq.rs
@@ -387,6 +387,24 @@ mod test_slice {
     }
 }
 
+mod test_vec {
+    mod test_f32 {
+        #[test]
+        fn test_basic() {
+            assert_ulps_eq!(vec![1.0f32, 2.0f32], vec![1.0f32, 2.0f32]);
+            assert_ulps_ne!(vec![1.0f32, 2.0f32], vec![2.0f32, 1.0f32]);
+        }
+    }
+
+    mod test_f64 {
+        #[test]
+        fn test_basic() {
+            assert_ulps_eq!(vec![1.0f64, 2.0f64], vec![1.0f64, 2.0f64]);
+            assert_ulps_ne!(vec![1.0f64, 2.0f64], vec![2.0f64, 1.0f64]);
+        }
+    }
+}
+
 #[cfg(feature = "num-complex")]
 mod test_complex {
     extern crate num_complex;


### PR DESCRIPTION
Delegating to the existing slice impls.

Without these impls we could just compare two vecs as slices, but:
- It requires the `&v[..]` or `v.as_slice()` syntax, on both sides of the comparison
- The vecs have to outlive the assert (assigned to variables), meaning no one-liners like `assert_abs_diff_eq!(foo().as_slice() bar.as_slice())`