### PR TITLE
Fix a couple clippy lints, run cargo format

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,7 @@ where
     /// Replace the epsilon value with the one specified.
     #[inline]
     pub fn epsilon(self, epsilon: A::Epsilon) -> AbsDiff<A, B> {
-        AbsDiff { epsilon, ..self }
+        AbsDiff { epsilon }
     }
 
     /// Peform the equality comparison

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -84,39 +84,35 @@ macro_rules! __assert_approx {
     ($eq:ident, $given:expr, $expected:expr) => {{
         let (given, expected) = (&($given), &($expected));
 
-        if !$eq!(*given, *expected) {
-            panic!(
+        assert!($eq!(*given, *expected),
 "assert_{}!({}, {})
 
     left  = {:?}
     right = {:?}
 
 ",
-                stringify!($eq),
-                stringify!($given),
-                stringify!($expected),
-                given, expected,
-            );
-        }
+            stringify!($eq),
+            stringify!($given),
+            stringify!($expected),
+            given, expected,
+        );
     }};
     ($eq:ident, $given:expr, $expected:expr, $($opt:ident = $val:expr),+) => {{
         let (given, expected) = (&($given), &($expected));
 
-        if !$eq!(*given, *expected, $($opt = $val),+) {
-            panic!(
+        assert!($eq!(*given, *expected, $($opt = $val),+),
 "assert_{}!({}, {}, {})
 
     left  = {:?}
     right = {:?}
 
 ",
-                stringify!($eq),
-                stringify!($given),
-                stringify!($expected),
-                stringify!($($opt = $val),+),
-                given, expected,
-            );
-        }
+            stringify!($eq),
+            stringify!($given),
+            stringify!($expected),
+            stringify!($($opt = $val),+),
+            given, expected,
+        );
     }};
 }
 

--- a/src/relative_eq.rs
+++ b/src/relative_eq.rs
@@ -18,12 +18,8 @@ where
     fn default_max_relative() -> Self::Epsilon;
 
     /// A test for equality that uses a relative comparison if the values are far apart.
-    fn relative_eq(
-        &self,
-        other: &Rhs,
-        epsilon: Self::Epsilon,
-        max_relative: Self::Epsilon,
-    ) -> bool;
+    fn relative_eq(&self, other: &Rhs, epsilon: Self::Epsilon, max_relative: Self::Epsilon)
+        -> bool;
 
     /// The inverse of [`RelativeEq::relative_eq`].
     fn relative_ne(

--- a/src/ulps_eq.rs
+++ b/src/ulps_eq.rs
@@ -131,7 +131,7 @@ where
     fn ulps_eq(&self, other: &[B], epsilon: A::Epsilon, max_ulps: u32) -> bool {
         self.len() == other.len()
             && Iterator::zip(self.iter(), other)
-                .all(|(x, y)| A::ulps_eq(x, y, epsilon.clone(), max_ulps.clone()))
+                .all(|(x, y)| A::ulps_eq(x, y, epsilon.clone(), max_ulps))
     }
 }
 


### PR DESCRIPTION
The most important one for me is the first fix, for `if_then_panic`, as it is in a macro, so the lint leaks into dependent crates as well.
See: https://github.com/ruffle-rs/ruffle/pull/5400/checks?check_run_id=3761100603 (EDIT: This link has expired since, sorry...)

The rest are just extra little fixes, while I was here...

I also had one for `transmute_float_to_int`, but that should be addressed by https://github.com/brendanzab/approx/pull/63, so I removed it from here.