### PR TITLE
Add CI based on Github Actions

### DIFF
--- a/.github/Xargo.toml
+++ b/.github/Xargo.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu.dependencies]
+alloc = {}

--- a/.github/ci-build.yml
+++ b/.github/ci-build.yml
@@ -1,0 +1,43 @@
+name: Approx CI build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check formatting
+        run: cargo fmt -- --check
+  build-native:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - name: Build approx
+        run: cargo build;
+      - name: Run tests
+        run: cargo test;
+  build-no-std:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          components: rustfmt
+      - name: install xargo
+        run: cp .github/Xargo.toml .; rustup component add rust-src; cargo install -f xargo;
+      - name: build x86_64-unknown-linux-gnu
+        run: xargo build --verbose --no-default-features --target=x86_64-unknown-linux-gnu;

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,13 +16,31 @@ jobs:
       - uses: actions/checkout@v2
       - name: Check formatting
         run: cargo fmt -- --check
-  build-native:
+  build-latest:
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
     steps:
-      - name: Build approx
-        run: cargo build;
+      - uses: actions/checkout@v2
+      - run: cargo build --no-default-features;
+      - run: cargo build;
+      - run: cargo build --features num-complex;
+      - name: Run tests
+        run: cargo test;
+  build-1.31.0:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - name: Install stable-2021-12-04
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: "1.31.0"
+          override: true
+      - uses: actions/checkout@v2
+      - run: cargo build --no-default-features;
+      - run: cargo build;
+      - run: cargo build --features num-complex;
       - name: Run tests
         run: cargo test;
   build-no-std:
@@ -36,7 +54,6 @@ jobs:
         with:
           toolchain: nightly
           override: true
-          components: rustfmt
       - name: install xargo
         run: cp .github/Xargo.toml .; rustup component add rust-src; cargo install -f xargo;
       - name: build x86_64-unknown-linux-gnu

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,7 +27,7 @@ jobs:
       - run: cargo build --features num-complex;
       - name: Run tests
         run: cargo test;
-  build-1.31.0:
+  build-1-31-0:
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings

--- a/src/ulps_eq.rs
+++ b/src/ulps_eq.rs
@@ -1,7 +1,7 @@
-use core::{cell, mem};
+use core::cell;
 #[cfg(feature = "num-complex")]
 use num_complex::Complex;
-use num_traits::{float::FloatCore, Signed};
+use num_traits::Signed;
 
 use AbsDiffEq;
 


### PR DESCRIPTION
It looks like the CI based on Travis-CI isn’t active any more? I don’t have a hand on Travis-CI, and I think it would be easier to just switch to Github Actions instead.