### PR TITLE
feat: Duration Support

### DIFF
--- a/approx/src/abs_diff_eq.rs
+++ b/approx/src/abs_diff_eq.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 use core::cell;
 #[cfg(feature = "indexmap_impl")]
 use core::hash::{BuildHasher, Hash};
+use core::time::Duration;
 #[cfg(feature = "indexmap_impl")]
 use indexmap::IndexMap;
 #[cfg(feature = "num_complex")]
@@ -304,6 +305,18 @@ mod abs_diff_eq_tuple_impls {
     impl_abs_diff_eq!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     impl_abs_diff_eq!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     impl_abs_diff_eq!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+}
+
+impl AbsDiffEq for Duration {
+    type Epsilon = Self;
+
+    fn default_epsilon() -> Self::Epsilon {
+        Duration::from_nanos(0)
+    }
+
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+        self.abs_diff(*other) <= epsilon
+    }
 }
 
 #[cfg(feature = "vec_impl")]

--- a/approx/tests/abs_diff_eq.rs
+++ b/approx/tests/abs_diff_eq.rs
@@ -682,6 +682,18 @@ mod test_indexmap {
     }
 }
 
+mod test_duration {
+    use core::time::Duration;
+
+    #[test]
+    fn test_basic() {
+        assert_abs_diff_eq!(Duration::from_secs(1), Duration::from_secs(1));
+        assert_abs_diff_ne!(Duration::from_secs(1), Duration::from_secs(2));
+        assert_abs_diff_ne!(Duration::from_secs(1), Duration::new(1, 10), epsilon = Duration::from_nanos(1));
+        assert_abs_diff_eq!(Duration::from_secs(1), Duration::new(1, 10), epsilon = Duration::from_nanos(100));
+    }
+}
+
 #[test]
 fn test_debug_abs_diff() {
     let x = 1.0;


### PR DESCRIPTION
Added support for the core duration type for abs_diff_eq as mentioned in #103 

Default is to treat it similar to an unsigned value with 0 epsilon but included tests allowing greater epsilon values.