### PR TITLE
Remove `num_traits` dependency.

### DIFF
--- a/approx/Cargo.toml
+++ b/approx/Cargo.toml
@@ -36,7 +36,6 @@ ordered_float = ["dep:ordered-float"]
 num_complex = ["dep:num-complex"]
 
 [dependencies]
-num-traits = { version = "0.2", default-features = false }
 num-complex = { version = "0.4", optional = true }
 ordered-float = { version = "5", optional = true }
 approx-derive = { path = "../approx-derive/", version = "0.6.0-rc2", optional = true }

--- a/approx/src/abs_diff_eq.rs
+++ b/approx/src/abs_diff_eq.rs
@@ -9,8 +9,6 @@ use indexmap::IndexMap;
 #[cfg(feature = "num_complex")]
 use num_complex::Complex;
 #[cfg(feature = "ordered_float")]
-use num_traits::Float;
-#[cfg(feature = "ordered_float")]
 use ordered_float::{NotNan, OrderedFloat};
 
 /// Equality that is defined using the absolute difference of two numbers.
@@ -376,7 +374,7 @@ impl<T: AbsDiffEq + Copy> AbsDiffEq for NotNan<T> {
 
 #[cfg(feature = "ordered_float")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ordered_float")))]
-impl<T: AbsDiffEq + Float + ordered_float::FloatCore> AbsDiffEq<T> for NotNan<T> {
+impl<T: AbsDiffEq + ordered_float::FloatCore> AbsDiffEq<T> for NotNan<T> {
     type Epsilon = T::Epsilon;
 
     #[inline]
@@ -392,7 +390,7 @@ impl<T: AbsDiffEq + Float + ordered_float::FloatCore> AbsDiffEq<T> for NotNan<T>
 
 #[cfg(feature = "ordered_float")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ordered_float")))]
-impl<T: AbsDiffEq + Float + ordered_float::FloatCore> AbsDiffEq for OrderedFloat<T> {
+impl<T: AbsDiffEq + ordered_float::FloatCore> AbsDiffEq for OrderedFloat<T> {
     type Epsilon = T::Epsilon;
 
     #[inline]
@@ -408,7 +406,7 @@ impl<T: AbsDiffEq + Float + ordered_float::FloatCore> AbsDiffEq for OrderedFloat
 
 #[cfg(feature = "ordered_float")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ordered_float")))]
-impl<T: AbsDiffEq + Float + ordered_float::FloatCore> AbsDiffEq<T> for OrderedFloat<T> {
+impl<T: AbsDiffEq + ordered_float::FloatCore> AbsDiffEq<T> for OrderedFloat<T> {
     type Epsilon = T::Epsilon;
 
     #[inline]

--- a/approx/src/abs_diff_eq.rs
+++ b/approx/src/abs_diff_eq.rs
@@ -99,7 +99,6 @@ macro_rules! impl_signed_abs_diff_eq {
             #[inline]
             #[allow(unused_imports)]
             fn abs_diff_eq(&self, other: &$T, epsilon: $T) -> bool {
-                use num_traits::float::FloatCore;
                 $T::abs(self - other) <= epsilon
             }
         }

--- a/approx/src/lib.rs
+++ b/approx/src/lib.rs
@@ -226,7 +226,6 @@
 #[cfg(feature = "num_complex")]
 #[cfg_attr(docsrs, doc(cfg(feature = "num_complex")))]
 extern crate num_complex;
-extern crate num_traits;
 #[cfg(feature = "ordered_float")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ordered_float")))]
 extern crate ordered_float;

--- a/approx/src/relative_eq.rs
+++ b/approx/src/relative_eq.rs
@@ -10,8 +10,6 @@ use indexmap::IndexMap;
 use num_complex::Complex;
 
 #[cfg(feature = "ordered_float")]
-use num_traits::Float;
-#[cfg(feature = "ordered_float")]
 use ordered_float::{NotNan, OrderedFloat};
 
 /// Equality comparisons between two numbers using both the absolute difference and
@@ -464,7 +462,7 @@ impl<T: RelativeEq + Copy> RelativeEq for NotNan<T> {
 
 #[cfg(feature = "ordered_float")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ordered_float")))]
-impl<T: RelativeEq + Float + ordered_float::FloatCore> RelativeEq<T> for NotNan<T> {
+impl<T: RelativeEq + ordered_float::FloatCore> RelativeEq<T> for NotNan<T> {
     #[inline]
     fn default_relative_epsilon() -> Self::Epsilon {
         T::default_relative_epsilon()
@@ -483,7 +481,7 @@ impl<T: RelativeEq + Float + ordered_float::FloatCore> RelativeEq<T> for NotNan<
 
 #[cfg(feature = "ordered_float")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ordered_float")))]
-impl<T: RelativeEq + Float + ordered_float::FloatCore> RelativeEq for OrderedFloat<T> {
+impl<T: RelativeEq + ordered_float::FloatCore> RelativeEq for OrderedFloat<T> {
     #[inline]
     fn default_relative_epsilon() -> Self::Epsilon {
         T::default_relative_epsilon()
@@ -512,7 +510,7 @@ impl<T: RelativeEq + Float + ordered_float::FloatCore> RelativeEq for OrderedFlo
 
 #[cfg(feature = "ordered_float")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ordered_float")))]
-impl<T: RelativeEq + Float + ordered_float::FloatCore> RelativeEq<T> for OrderedFloat<T> {
+impl<T: RelativeEq + ordered_float::FloatCore> RelativeEq<T> for OrderedFloat<T> {
     #[inline]
     fn default_relative_epsilon() -> Self::Epsilon {
         T::default_relative_epsilon()

--- a/approx/src/relative_eq.rs
+++ b/approx/src/relative_eq.rs
@@ -86,7 +86,6 @@ macro_rules! impl_relative_eq {
             #[inline]
             #[allow(unused_imports)]
             fn relative_eq(&self, other: &$T, epsilon: $T, max_relative: $T) -> bool {
-                use num_traits::float::FloatCore;
                 // Handle same infinities
                 if self == other {
                     return true;

--- a/approx/src/ulps_eq.rs
+++ b/approx/src/ulps_eq.rs
@@ -8,9 +8,6 @@ use indexmap::IndexMap;
 #[cfg(feature = "num_complex")]
 use num_complex::Complex;
 #[cfg(feature = "ordered_float")]
-use num_traits::Float;
-use num_traits::Signed;
-#[cfg(feature = "ordered_float")]
 use ordered_float::{NotNan, OrderedFloat};
 
 use crate::AbsDiffEq;

--- a/approx/src/ulps_eq.rs
+++ b/approx/src/ulps_eq.rs
@@ -321,7 +321,7 @@ impl<T: UlpsEq + Copy> UlpsEq for NotNan<T> {
 
 #[cfg(feature = "ordered_float")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ordered_float")))]
-impl<T: UlpsEq + Float + ordered_float::FloatCore> UlpsEq<T> for NotNan<T> {
+impl<T: UlpsEq + ordered_float::FloatCore> UlpsEq<T> for NotNan<T> {
     #[inline]
     fn default_max_ulps() -> u32 {
         T::default_max_ulps()
@@ -335,7 +335,7 @@ impl<T: UlpsEq + Float + ordered_float::FloatCore> UlpsEq<T> for NotNan<T> {
 
 #[cfg(feature = "ordered_float")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ordered_float")))]
-impl<T: UlpsEq + Float + ordered_float::FloatCore> UlpsEq for OrderedFloat<T> {
+impl<T: UlpsEq + ordered_float::FloatCore> UlpsEq for OrderedFloat<T> {
     #[inline]
     fn default_max_ulps() -> u32 {
         T::default_max_ulps()
@@ -349,7 +349,7 @@ impl<T: UlpsEq + Float + ordered_float::FloatCore> UlpsEq for OrderedFloat<T> {
 
 #[cfg(feature = "ordered_float")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ordered_float")))]
-impl<T: UlpsEq + Float + ordered_float::FloatCore> UlpsEq<T> for OrderedFloat<T> {
+impl<T: UlpsEq + ordered_float::FloatCore> UlpsEq<T> for OrderedFloat<T> {
     #[inline]
     fn default_max_ulps() -> u32 {
         T::default_max_ulps()


### PR DESCRIPTION
It would be nice if we didn't need to pull in `num_traits` to use this.

The only reason I can think of to not do this if it it would somehow not work on older rust versions.
But, I don't *think* this would actually cause any problems, and I didn't see a MSRV anywhere.

(`cargo test` passes locally. Let me know if there's any other test's you'd like me to run or anything!)